### PR TITLE
RDK-49475: Remove BBMASK for wayland bbappend

### DIFF
--- a/conf/include/rdke-vendor-bbmask.inc
+++ b/conf/include/rdke-vendor-bbmask.inc
@@ -2,8 +2,6 @@
 BBMASK += " meta-rdk-oss-reference/recipes-support/cryptsetup/cryptsetup_1.7.2.bbappend"
 BBMASK += " meta-rdk-oss-reference/recipes-support/lvm2/lvm2_2.02.138.bbappend"
 BBMASK += " meta-rdk-oss-reference/recipes-mac/Apparmor/apparmor_%.bbappend"
-#See RDK-49475 in Comcast jira. Remove when fixed from OSS layer.
-BBMASK += " meta-rdk-oss-reference/recipes-graphics/wayland/wayland_%.bbappend"
 
 #From meta-openembedded
 BBMASK += " meta-openembedded/meta-multimedia/recipes-multimedia/tinyalsa/tinyalsa.bb"


### PR DESCRIPTION
Reason for change: libwayland-egl libraries are packaged under wayland-default-egl
Test Procedure: Build and verify
Risks: Low
Priority: P1