### PR TITLE
Add wayland-default-egl to packagegroup-vendor-layer

### DIFF
--- a/recipes-core/packagegroups/packagegroup-vendor-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-vendor-layer.bb
@@ -44,4 +44,5 @@ RDEPENDS_${PN}:append:rdkv-oss = "\
         pango \
 	pulseaudio \
 	libmms \
+    wayland-default-egl \
         "


### PR DESCRIPTION
require OSS vesion 3.0.3.
This is a temporary change until OSS fixes the wayland recipe.