### PR TITLE
RDKE-125 Integrate bluez5, bluetooth-mgr and bluetooth-core

### DIFF
--- a/recipes-core/packagegroups/packagegroup-vendor-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-vendor-layer.bb
@@ -12,6 +12,7 @@ PV = "1.0.0"
 PR = "r0"
 
 RDEPENDS_${PN} = " \
+        pi-bluetooth \
         sysint-soc \
         westeros-soc-drm \
         "
@@ -46,5 +47,4 @@ RDEPENDS_${PN}:append:rdkv-oss = " \
         westeros-simplebuffer \
         westeros-simpleshell \
         westeros-sink \
-        pi-bluetooth \
         "

--- a/recipes-core/packagegroups/packagegroup-vendor-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-vendor-layer.bb
@@ -46,4 +46,5 @@ RDEPENDS_${PN}:append:rdkv-oss = " \
         westeros-simplebuffer \
         westeros-simpleshell \
         westeros-sink \
+        pi-bluetooth \
         "


### PR DESCRIPTION
Reason for change: Added the runtime dependency package group.
Test Procedure: build and verify.
Risks: low.
Signed-off-by: Dinesh_kumar2@comcast.com.