### PR TITLE
RDKE-143 Add missing virtual PROVIDES

### DIFF
--- a/recipes-graphics/westeros/westeros-sink.bbappend
+++ b/recipes-graphics/westeros/westeros-sink.bbappend
@@ -1,5 +1,7 @@
 S = "${WORKDIR}/git"
 
+PROVIDES = "virtual/vendor-westeros-sink"
+
 SINK_SOC_PATH = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', 'v4l2', 'rpi', d)}"
 
 AUTOTOOLS_SCRIPT_PATH = "${S}/${SINK_SOC_PATH}/westeros-sink"

--- a/recipes-halif/devicesettings/devicesettings-hal-raspberrypi4.bb
+++ b/recipes-halif/devicesettings/devicesettings-hal-raspberrypi4.bb
@@ -6,7 +6,7 @@ SECTION = "console/utils"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=175792518e4ac015ab6696d16c4f607e"
 
-PROVIDES = "virtual/devicesettings-hal"
+PROVIDES = "virtual/devicesettings-hal virtual/vendor-devicesettings-hal"
 RPROVIDES_${PN} = "virtual/devicesettings-hal"
 
 # a HAL is machine specific

--- a/recipes-halif/iarmmgrs/iarmmgrs-hal-raspberrypi4.bb
+++ b/recipes-halif/iarmmgrs/iarmmgrs-hal-raspberrypi4.bb
@@ -2,7 +2,7 @@ DESCRIPTION = "IARMMGRS HAL Implementation - IR, Power & Deepsleep."
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b1e01b26bacfc2232046c90a330332b3"
 
-PROVIDES = "virtual/iarmmgrs-hal"
+PROVIDES = "virtual/iarmmgrs-hal virtual/vendor-iarmmgrs-hal"
 
 # Future: RDK-48312 says IARMMGRS HAL will be split into Power & DeepSleep.
 # Rename this recipe as Power Manager HAL when this happens and introduce another for DeepSleep.


### PR DESCRIPTION
PROVIDES virtual for westeros-sink, vendor-devicesettings-hal, and vendor-iarmmgrs-hal are required by middleware when doing a full stack build