### PR TITLE
RDKE-151: Add gstreamer1.0-rtsp-server in pkggrp

### DIFF
--- a/conf/include/vendor_pkg_versions.inc
+++ b/conf/include/vendor_pkg_versions.inc
@@ -133,6 +133,11 @@ PR_pn-gstreamer1.0-plugins-bad-meta = "${GST_REVISION}"
 PACKAGE_ARCH_pn-gstreamer1.0-plugins-bad-meta = "${VENDOR_LAYER_EXTENSION}"
 PREFERRED_VERSION_gstreamer1.0-plugins-bad-meta ?= "${GST_VERSION}"
 
+PV_pn-gstreamer1.0-rtsp-server = "${GST_VERSION}"
+PR_pn-gstreamer1.0-rtsp-server = "${GST_REVISION}"
+PACKAGE_ARCH_pn-gstreamer1.0-rtsp-server = "${VENDOR_LAYER_EXTENSION}"
+PREFERRED_VERSION_gstreamer1.0-rtsp-server ?= "${GST_VERSION}"
+
 # Westeros components
 WESTEROS_VERSION = "1.0.0"
 WESTEROS_REVISION = "r0"

--- a/recipes-core/packagegroups/packagegroup-vendor-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-vendor-layer.bb
@@ -35,6 +35,7 @@ RDEPENDS_${PN}:append:rdkv-oss = " \
         gstreamer1.0-plugins-base-meta \
         gstreamer1.0-plugins-good \
         gstreamer1.0-plugins-good-meta \
+        gstreamer1.0-rtsp-server \
         libdrm \
         libepoxy \
         libmms \


### PR DESCRIPTION
gstreamer1.0-rtsp-server is from OSS and is required for resolving the RDEPENDS error while building upper layers.