### PR TITLE
RDKVREFPLT-3124: Recipe uses a floating tag/branch without a fixed SRCREV

### DIFF
--- a/conf/include/vendor_pkg_versions.inc
+++ b/conf/include/vendor_pkg_versions.inc
@@ -177,27 +177,27 @@ SRCREV:pn-westeros-sink = "${WESTEROS_SRCREV}"
 # RDKV HAL component versions
 
 # RDKV HAL component versions of raspberrypi4
-SRCREV:pn-devicesettings-hal-raspberrypi4 = "1.0.2"
+SRCREV:pn-devicesettings-hal-raspberrypi4 = "7419888aaa9a3125980f81a324f6ad4fb83caa7b"
 #PV:pn-devicesettings-hal-raspberrypi4 = "2.0.0"
 PR:pn-devicesettings-hal-raspberrypi4 = "r0"
 PACKAGE_ARCH:pn-devicesettings-hal-raspberrypi4 = "${VENDOR_LAYER_EXTENSION}"
 
-SRCREV:pn-hdmicec-hal-raspberrypi4 = "1.0.1"
+SRCREV:pn-hdmicec-hal-raspberrypi4 = "81610f5daf4f2167a30ad9aae8e18c2846e51530"
 #PV:pn-hdmicec-hal-raspberrypi4 = "1.0.0"
 PR:pn-hdmicec-hal-raspberrypi4 = "r0"
 PACKAGE_ARCH:pn-hdmicec-hal-raspberrypi4 = "${VENDOR_LAYER_EXTENSION}"
 
-SRCREV:pn-iarmmgrs-hal-raspberrypi4 = "1.0.1"
+SRCREV:pn-iarmmgrs-hal-raspberrypi4 = "f174dc2bec24db8d19a2b384c6dccfaaa530c775"
 #PV:pn-iarmmgrs-hal-raspberrypi4 = "2.0.1"
 PR:pn-iarmmgrs-hal-raspberrypi4 = "r0"
 PACKAGE_ARCH:pn-iarmmgrs-hal-raspberrypi4 = "${VENDOR_LAYER_EXTENSION}"
 
-SRCREV:pn-mfrlibs-hal-raspberrypi4 = "1.0.1"
+SRCREV:pn-mfrlibs-hal-raspberrypi4 = "9522f49f92e7eed8c63c732c2f245012454b0f4b"
 #PV:pn-mfrlibs-hal-raspberrypi4 = "1.0.0"
 PR:pn-mfrlibs-hal-raspberrypi4 = "r0"
 PACKAGE_ARCH:pn-mfrlibs-hal-raspberrypi4 = "${VENDOR_LAYER_EXTENSION}"
 
-SRCREV:pn-sysint-soc = "1.0.2"
+SRCREV:pn-sysint-soc = "9b9dc358b27f56b1e1a0d993da4ed5159714dd5a"
 #PV:pn-sysint-soc = "1.0.2"
 PR:pn-sysint-soc = "r0"
 PACKAGE_ARCH:pn-sysint-soc = "${VENDOR_LAYER_EXTENSION}"

--- a/recipes-graphics/userland/userland_git.bbappend
+++ b/recipes-graphics/userland/userland_git.bbappend
@@ -37,3 +37,6 @@ FILES:${PN}:append = "\
 
 # no EGL runtime providers for vc4graphics
 RPROVIDES:${PN}:remove = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', 'libegl', '', d)}"
+
+# Fix do_package_qa err
+INSANE_SKIP:${PN}-dev = " staticdev"

--- a/recipes-kernel/android/android-raspberrypi.inc
+++ b/recipes-kernel/android/android-raspberrypi.inc
@@ -15,14 +15,14 @@ require recipes-kernel/linux/linux-yocto.inc
 SRC_URI += "file://rpi-kernel-misc.cfg"
 
 KCONFIG_MODE = "--alldefconfig"
-KBUILD_DEFCONFIG_raspberrypi0-wifi ?= "bcmrpi_defconfig"
-KBUILD_DEFCONFIG_raspberrypi ?= "bcmrpi_defconfig"
-KBUILD_DEFCONFIG_raspberrypi-cm3 ?= "bcm2709_defconfig"
-KBUILD_DEFCONFIG_raspberrypi2 ?= "bcm2709_defconfig"
-KBUILD_DEFCONFIG_raspberrypi3 ?= "bcm2709_defconfig"
-KBUILD_DEFCONFIG_raspberrypi3-64 ?= "bcmrpi3_defconfig"
-KBUILD_DEFCONFIG_raspberrypi4 ?= "bcm2711_defconfig"
-KBUILD_DEFCONFIG_raspberrypi4-64 ?= "bcm2711_defconfig"
+KBUILD_DEFCONFIG:raspberrypi0-wifi ?= "bcmrpi_defconfig"
+KBUILD_DEFCONFIG:raspberrypi ?= "bcmrpi_defconfig"
+KBUILD_DEFCONFIG:raspberrypi-cm3 ?= "bcm2709_defconfig"
+KBUILD_DEFCONFIG:raspberrypi2 ?= "bcm2709_defconfig"
+KBUILD_DEFCONFIG:raspberrypi3 ?= "bcm2709_defconfig"
+KBUILD_DEFCONFIG:raspberrypi3-64 ?= "bcmrpi3_defconfig"
+KBUILD_DEFCONFIG:raspberrypi4 ?= "bcm2711_defconfig"
+KBUILD_DEFCONFIG:raspberrypi4-64 ?= "bcm2711_defconfig"
 
 LINUX_VERSION_EXTENSION ?= ""
 


### PR DESCRIPTION
Reason for change: Fix all floating tag/branch to a fixed SRCREV
Test Procedure: Build and Verify
Risks: Low