### PR TITLE
RDKVREFPLT-3127: android-raspberrypi 5.10 kernel build compile error

### DIFF
--- a/recipes-kernel/android/android-raspberrypi.inc
+++ b/recipes-kernel/android/android-raspberrypi.inc
@@ -123,11 +123,9 @@ do_configure:prepend() {
     rm -f ${B}/.config.patched
 }
 
-
 do_compile:append() {
-    if [ "${SITEINFO_BITS}" = "64" ]; then
-        cc_extra=$(get_cc_option)
-        oe_runmake dtbs CC="${KERNEL_CC} $cc_extra " LD="${KERNEL_LD}" ${KERNEL_EXTRA_ARGS}
+   if [ "${SITEINFO_BITS}" = "64" ]; then
+        oe_runmake dtbs CC="${KERNEL_CC} " LD="${KERNEL_LD}" ${KERNEL_EXTRA_ARGS}
     fi
 }
 


### PR DESCRIPTION
Reason for change: Fix build error get_cc_option: not found