### PR TITLE
RDKVREFPLT-3127: Resolving build errors - android-raspberrypi do_deply

### DIFF
--- a/recipes-bsp/bootfiles/rpi-cmdline.bbappend
+++ b/recipes-bsp/bootfiles/rpi-cmdline.bbappend
@@ -1,0 +1,7 @@
+do_compile:append() {
+
+   if [ "${@bb.utils.contains("DISTRO_FEATURES", "DOBBY_CONTAINERS", "yes", "no", d)}" = "yes" ]; then
+        sed -i 's/[[:space:]]*$//g' ${WORKDIR}/cmdline.txt
+        sed -i 's/$/ cgroup_enable=memory cgroup_memory=1/' ${WORKDIR}/cmdline.txt
+   fi
+}

--- a/recipes-kernel/android/android-raspberrypi.inc
+++ b/recipes-kernel/android/android-raspberrypi.inc
@@ -26,21 +26,6 @@ KBUILD_DEFCONFIG:raspberrypi4-64 ?= "bcm2711_defconfig"
 
 LINUX_VERSION_EXTENSION ?= ""
 
-# CMDLINE for raspberrypi
-SERIAL = "${@oe.utils.conditional("ENABLE_UART", "1", "console=serial0,115200", "", d)}"
-CMDLINE ?= "dwc_otg.lpm_enable=0 ${SERIAL} root=/dev/mmcblk0p2 rootfstype=ext4 rootwait"
-
-# Add the kernel debugger over console kernel command line option if enabled
-CMDLINE:append = ' ${@oe.utils.conditional("ENABLE_KGDB", "1", "kgdboc=serial0,115200", "", d)}'
-
-# Disable rpi logo on boot
-CMDLINE:append += ' ${@oe.utils.conditional("DISABLE_RPI_BOOT_LOGO", "1", "logo.nologo", "", d)}'
-
-# You can define CMDLINE_DEBUG as "debug" in your local.conf or distro.conf
-# to enable kernel debugging.
-CMDLINE_DEBUG ?= ""
-CMDLINE:append = " ${CMDLINE_DEBUG}"
-
 KERNEL_MODULE_AUTOLOAD += "${@bb.utils.contains("MACHINE_FEATURES", "pitft28r", "stmpe-ts", "", d)}"
 
 # A LOADADDR is needed when building a uImage format kernel. This value is not
@@ -129,14 +114,3 @@ do_compile:append() {
     fi
 }
 
-do_deploy:append() {
-    # Deploy cmdline.txt only for the main kernel package
-    if [ ${KERNEL_PACKAGE_NAME} = "kernel" ]; then
-        install -d ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}
-        PITFT="${@bb.utils.contains("MACHINE_FEATURES", "pitft", "1", "0", d)}"
-        if [ ${PITFT} = "1" ]; then
-            PITFT_PARAMS="fbcon=map:10 fbcon=font:VGA8x8"
-        fi
-        echo "${CMDLINE}${PITFT_PARAMS}" > ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/cmdline.txt
-    fi
-}

--- a/recipes-kernel/android/android-raspberrypi_%.bbappend
+++ b/recipes-kernel/android/android-raspberrypi_%.bbappend
@@ -1,14 +1,6 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
-SRC_URI:append_hybrid = " file://rdkv.cfg"
+SRC_URI:append:hybrid = " file://rdkv.cfg"
 SRC_URI:append:client = " file://rdkv.cfg"
-SRC_URI:append_ipclient = " file://rdkv.cfg"
+SRC_URI:append:ipclient = " file://rdkv.cfg"
 
-do_deploy:append() {
-   if [ "${@bb.utils.contains("DISTRO_FEATURES", "DOBBY_CONTAINERS", "yes", "no", d)}" = "yes" ]; then
-        if [ -f "${DEPLOYDIR}/bootfiles/cmdline.txt" ]; then
-            sed -i 's/[[:space:]]*$//g' ${DEPLOYDIR}/bootfiles/cmdline.txt
-            sed -i 's/$/ cgroup_enable=memory cgroup_memory=1/' ${DEPLOYDIR}/bootfiles/cmdline.txt
-        fi
-   fi
-}


### PR DESCRIPTION
Reason for change: kirkstone meta-raspberrypi upstream provides new bb (reciped-bsb/bootfiles/rpi-cmdline.bb) file for cmdline operation