### PR TITLE
RDKVREFPLT-3153: Use kirkstone version of wayland-default-egl recipe

### DIFF
--- a/conf/include/vendor_pkg_versions.inc
+++ b/conf/include/vendor_pkg_versions.inc
@@ -174,10 +174,9 @@ PR:pn-westeros-sink = "${WESTEROS_REVISION}"
 PACKAGE_ARCH:pn-westeros-sink = "${VENDOR_LAYER_EXTENSION}"
 SRCREV:pn-westeros-sink = "${WESTEROS_SRCREV}"
 
-PV:pn-wayland-default-egl = "1.18.0"
+#PV:pn-wayland-default-egl = "1.20.0"
 PR:pn-wayland-default-egl = "r0"
 PACKAGE_ARCH:pn-wayland-default-egl = "${VENDOR_LAYER_EXTENSION}"
-SRCREV:pn-wayland-default-egl = "1.18.0"
 
 # RDKV HAL component versions
 


### PR DESCRIPTION
Update wayland-default-egl recipe to kirkstone version of wayland recipe(1.20.0)