### PR TITLE
RDKVREFPLT-3162: MW HAL refactoring requirement

### DIFF
--- a/recipes-halif/iarmmgrs/iarmmgrs-hal-raspberrypi4.bb
+++ b/recipes-halif/iarmmgrs/iarmmgrs-hal-raspberrypi4.bb
@@ -5,6 +5,10 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=b1e01b26bacfc2232046c90a330332b3"
 PROVIDES = "virtual/iarmmgrs-hal virtual/vendor-iarmmgrs-hal"
 RPROVIDES_${PN} = "virtual/iarmmgrs-hal virtual/vendor-iarmmgrs-hal"
 
+# TODO: Move to respective recipe when available
+PROVIDES += " virtual/vendor-pwrmgr-hal virtual/vendor-deepsleepmgr-hal "
+RPROVIDES_${PN} += " virtual/vendor-pwrmgr-hal virtual/vendor-deepsleepmgr-hal "
+
 # Future: RDK-48312 says IARMMGRS HAL will be split into Power & DeepSleep.
 # Rename this recipe as Power Manager HAL when this happens and introduce another for DeepSleep.
 # IR Manager will get deprecated and replaced by udev or similar.


### PR DESCRIPTION
Latest MW requires PWRMGR and DEEPSLEEP HALSs as virtual.