### PR TITLE
RDKVREFPLT-3687: use the latest DSHAL v1.0.4

### DIFF
--- a/conf/include/vendor_pkg_versions.inc
+++ b/conf/include/vendor_pkg_versions.inc
@@ -182,7 +182,7 @@ SRCREV_pn-wayland-default-egl = "1.18.0"
 # RDKV HAL component versions
 
 # RDKV HAL component versions of raspberrypi4
-SRCREV_pn-devicesettings-hal-raspberrypi4 = "1.0.3"
+SRCREV_pn-devicesettings-hal-raspberrypi4 = "1.0.4"
 PV_pn-devicesettings-hal-raspberrypi4 = "2.0.0"
 PR_pn-devicesettings-hal-raspberrypi4 = "r0"
 PACKAGE_ARCH_pn-devicesettings-hal-raspberrypi4 = "${VENDOR_LAYER_EXTENSION}"


### PR DESCRIPTION
This includes the following:
- Stub implementation for dsHdmiIn.h
- Bugfix of REFPLTV-2489